### PR TITLE
Generalize crime viz to incomplete trajectories

### DIFF
--- a/commonroad_crime/utility/visualization.py
+++ b/commonroad_crime/utility/visualization.py
@@ -317,24 +317,33 @@ def visualize_scenario_at_time_steps(
     scenario: Scenario, plot_limit, time_steps: List[int]
 ):
     rnd = MPRenderer(plot_limits=plot_limit)
-    rnd.draw_params.time_begin = time_steps[0]
-    if time_steps:
-        rnd.draw_params.time_end = time_steps[-1]
+
+    assert isinstance(time_steps, list)
+    plot_begin: int = time_steps[0]
+    plot_end: int = time_steps[-1]
+    rnd.draw_params.time_begin = plot_begin
+    rnd.draw_params.time_end = plot_end
+
     rnd.draw_params.trajectory.draw_trajectory = False
     rnd.draw_params.dynamic_obstacle.draw_icon = True
     scenario.draw(rnd)
     rnd.render()
     for obs in scenario.obstacles:
+        plot_traj_begin_time_step = max(obs.prediction.initial_time_step, plot_begin)
+        plot_traj_end_time_step = min(obs.prediction.final_time_step, plot_end)
+        plot_traj_begin_index = plot_traj_begin_time_step - obs.prediction.initial_time_step
+        plot_traj_end_index = plot_traj_end_time_step - obs.prediction.initial_time_step
+
         draw_state_list(
             rnd,
-            obs.prediction.trajectory.state_list[time_steps[0] : time_steps[-1] + 1],
+            obs.prediction.trajectory.state_list[plot_traj_begin_index: plot_traj_end_index + 1],
             color=TUMcolor.TUMblue,
             linewidth=5,
         )
-        for ts in time_steps[1:]:
-            draw_dyn_vehicle_shape(rnd, obs, ts, color=TUMcolor.TUMblue)
+        for ts in time_steps:
+            if plot_traj_begin_time_step <= ts <= plot_traj_end_time_step:
+                draw_dyn_vehicle_shape(rnd, obs, ts, color=TUMcolor.TUMblue)
     plt.show()
-
 
 def make_gif(
     path: str,


### PR DESCRIPTION
Hi :wave: 

I think so far, this visualization function assumed that all obstacles' trajectories would start at time step 1 and go until the end of the scenario (e.g. 20). 

I noticed something was off when the argument `time_steps = [20]` led to an error. `state_list[time_steps[0] : time_steps[-1] + 1]` becomes `state_list[20:21]` then, but the indices of `state_list` only go from 0 to 19 (for time steps 1 to 20).

Then I also realized it might be worth while fully generalizing it to the case that certain trajectories begin later than 1 and end sooner than 20, while the plot argument could still be `time_steps = [1, 20]` or even `[0,20]`. 

Is this worth while generalizing or are scenarios typically composed in a way all objects last from beginning to end? Since I don't know yet, I also haven't tested this function on such a scenario yet.