### PR TITLE
Use `os.path.join` for path operations to avoid trailing slashes

### DIFF
--- a/commonroad_crime/data_structure/configuration.py
+++ b/commonroad_crime/data_structure/configuration.py
@@ -208,20 +208,20 @@ class GeneralConfiguration(BaseConfig):
 
     # paths are relative to the root directory
     path_root_abs = os.path.normpath(os.path.join(os.path.dirname(__file__), "../.."))
-    path_scenarios: str = path_root_abs + "/scenarios/"
-    path_scenarios_batch: str = path_root_abs + "/scenarios/batch/"
-    path_output_abs: str = path_root_abs + "/output/"
-    path_logs: str = path_root_abs + "/output/logs/"
-    path_icons: str = path_root_abs + "/docs/icons/"
+    path_scenarios: str = os.path.join(path_root_abs, "scenarios")
+    path_scenarios_batch: str = os.path.join(path_root_abs, "scenarios/batch")
+    path_output_abs: str = os.path.join(path_root_abs, "output")
+    path_logs: str = os.path.join(path_root_abs, "output/logs")
+    path_icons: str = os.path.join(path_root_abs, "docs/icons")
     name_scenario: Optional[str] = None
 
     @property
     def path_scenario(self):
-        return self.path_scenarios + self.name_scenario + ".xml"
+        return os.path.join(self.path_scenarios, f"{self.name_scenario}.xml")
 
     @property
     def path_output(self):
-        return self.path_output_abs + self.name_scenario + "/"
+        return os.path.join(self.path_output_abs, self.name_scenario)
 
     def set_scenario_name(self, scenario_name: str):
         """

--- a/commonroad_crime/data_structure/crime_interface.py
+++ b/commonroad_crime/data_structure/crime_interface.py
@@ -191,7 +191,7 @@ class CriMeInterface:
         # Save to file
         tree = etree.ElementTree(root)
         tree.write(
-            f"{output_dir}/CriMe-{scenario.scenario_id}_veh_{self.config.vehicle.ego_id}.xml",
+            os.path.join(output_dir, f"CriMe-{scenario.scenario_id}_veh_{self.config.vehicle.ego_id}.xml"),
             pretty_print=True,
             xml_declaration=True,
             encoding="utf-8",

--- a/commonroad_crime/utility/visualization.py
+++ b/commonroad_crime/utility/visualization.py
@@ -53,7 +53,7 @@ def save_fig(
     # save as svg
     Path(path_output).mkdir(parents=True, exist_ok=True)
     plt.savefig(
-        f"{path_output}{measure_name}_{time_step:.0f}.{suffix}",
+        os.path.join(path_output, f"{measure_name}_{time_step:.0f}.{suffix}"),
         format=suffix,
         bbox_inches="tight",
         transparent=False,


### PR DESCRIPTION
When I set my own paths in `GeneralConfiguration` using `os.path.join` commands, there won't be trailing `/`, e.g. 

```python
own_paths = GeneralConfiguration(
    path_scenarios=get_own_scenarios_dir(),
    path_scenarios_batch=os.path.join(get_own_scenarios_dir(), "batch"),
    path_output_abs=os.path.join(get_own_root(), "data/crime_outputs"),
    path_logs=os.path.join(get_own_root(), "data/crime_outputs/logs"),
    path_icons=os.path.join(get_local_crime_root(), "docs/icons"),
)
```

However, without the trailing `/`, the path concatenation in the properties `path_scenario` or `path_output` breaks. 

Hence, I suggest avoiding trailing `/` (as these would get eliminated in `os.path.normpath`, too), and using `os.path.join` whenever possible.

Are there further locations that would need adaptation?

 